### PR TITLE
Add rename_constraint, rename_default_primary_key and rename_default_foreign_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,19 @@ There are several additional schema statements and data types available that you
         ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces =
           {:clob => 'TS_LOB', :blob => 'TS_LOB', :index => 'TS_INDEX', :table => 'TS_DATA'}
 
+  * `rename_constraint` to rename a constraint name, for example:
+
+        rename_constraint("TEST_POSTS", "TEST_POSTS_PK", "NEW_TEST_POSTS_PK")
+
+  * `rename_default_primary_key` and `rename_default_foreign_key` to rename them from 'SYS_C%' to '%_PK' and '%_FK'
+
+        # rename a primary key name from 'SYS_C%' to "PRODUCTS_PK"
+        rename_default_primary_key("PRODUCTS")
+        # rename a foreign key name from 'SYS_C%' to "ORDER_ITEMS_PRODUCTS_FK"
+        rename_default_foreign_key("ORDER_ITEMS")
+
+
+
 TROUBLESHOOTING
 ---------------
 


### PR DESCRIPTION
Add rename_constraint, rename_default_primary_key, rename_default_foreign_key methods and these tests.

At first I tried to modify oracle-enhanced to generate DDLs with non-default (SYS_C%) primary key
and foreign key name but I did not get how to do. Instead, implemented some methods to rename these constraints.

These tests have passed with Rails 3.1.1 with Oracle 11gR2 and Rails 3.0.9 with Oracle 10gR2.
I would be grateful if I can have your comments.
