### PR TITLE
Run RuboCop using GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Build and run RuboCop
       run: |
         bundle install --jobs 4 --retry 3
-        bundle exec rubocop
+        bundle exec rubocop --parallel

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,38 @@
+name: Ruby
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - name: Install required package
+      run: |
+        sudo apt-get install alien
+    - name: Download Oracle instant client
+      run: |
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/193000/oracle-instantclient19.3-basic-19.3.0.0.0-1.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/193000/oracle-instantclient19.3-sqlplus-19.3.0.0.0-1.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/193000/oracle-instantclient19.3-devel-19.3.0.0.0-1.x86_64.rpm
+    - name: Install Oracle instant client
+      run: |
+        sudo alien -i oracle-instantclient19.3-basic-19.3.0.0.0-1.x86_64.rpm
+        sudo alien -i oracle-instantclient19.3-sqlplus-19.3.0.0.0-1.x86_64.rpm
+        sudo alien -i oracle-instantclient19.3-devel-19.3.0.0.0-1.x86_64.rpm
+
+    - name: Update environment variables
+      run: |
+        export PATH=/usr/lib/oracle/19.3/client64/bin:$PATH
+        export LD_LIBRARY_PATH=/usr/lib/oracle/19.3/client64/lib:$LD_LIBRARY_PATH
+
+    - name: Build and run RuboCop
+      run: |
+        bundle install --jobs 4 --retry 3
+        bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ group :development do
   gem "rspec"
   gem "rdoc"
   gem "rake"
-  gem "rubocop", "~> 0.74.0", require: false
-  gem "rubocop-performance", "~> 1.3.0", require: false
-  gem "rubocop-rails", "~> 2.0.0", require: false
+  gem "rubocop", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
 
   gem "activerecord",   github: "rails/rails", branch: "master"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"


### PR DESCRIPTION
This pull request is a kind of POC to run RuboCop using GitHub Actions because GitHub Actions is not available at https://github.com/rsim/oracle-enhanced yet.

Currently, RuboCop at Oracle enhanced adapter CI is supported by Code Climate. To use the newer version of RuboCop requires new channels like `rubocop-0-74 ` https://github.com/codeclimate/codeclimate/releases/tag/v0.85.5 . Because RuboCop is actively developed and released it usually take some time when we get the latest version of RuboCop at CI. 

By running RuboCop at GitHub Actions, we can use the latest version of RuboCop immediately, the second commit of this pull request "unlocks" the version limitation of RuboCop families intentionally.

This POC is only attempting to run RuboCop, not RSpec because of:
* GitHub Actions does not support JRuby nor Ruby master yet
* I do not find a way to install Oracle Database 12c using GitHub Actions 

